### PR TITLE
History working!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: camunozg <camunozg@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/09/15 16:43:25 by juramos           #+#    #+#              #
-#    Updated: 2024/04/16 12:59:17 by camunozg         ###   ########.fr        #
+#    Updated: 2024/04/17 11:31:03 by camunozg         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -21,6 +21,7 @@ CFLAGS 		= 	-Wall -Werror -Wextra
 SRC_DIR 	= 	src/
 SRC_FILES 	= 	main\
 				init\
+				history\
 				signal_handler\
 				lexer/lexer_utils\
 				lexer/lexer\

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: camunozg <camunozg@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/16 11:27:08 by juramos           #+#    #+#             */
-/*   Updated: 2024/04/17 09:37:35 by camunozg         ###   ########.fr       */
+/*   Updated: 2024/04/17 11:30:34 by camunozg         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -118,9 +118,15 @@ char		*ft_strdup_mod(const char *s, size_t size);
 void		error(t_minishell *data, char *error_message);
 
 // SIGNALS
-void	signals(bool child_process);
-void	signal_handler(int signal);
-void	signal_handler_child(int signal);
+void		signals(bool child_process);
+void		signal_handler(int signal);
+void		signal_handler_child(int signal);
+
+// HISTORY
+void		join_history(char *cmd, t_minishell *data, char **envp);
+void		get_past_history(char **envp, t_minishell *data);
+void		load_history(int fd);
+char		*get_home(char **envp);
 
 // EXEC
 /*	exec */

--- a/src/history.c
+++ b/src/history.c
@@ -42,9 +42,7 @@ void	get_past_history(char **envp, t_minishell *data)
 	if (home)
 	{
 		home += 5;
-		// printf("%s\n",home);
-		// exit(0);
-		home = ft_strjoin(home, "./history");
+		home = ft_strjoin(home, "/.history");
 		if (!home)
 			error(data, "Memory problems when loading history");
 		fd = open(home, O_CREAT | O_RDWR | O_APPEND, 0644);
@@ -66,7 +64,7 @@ void	join_history(char *cmd, t_minishell *data, char **envp)
 	if (home)
 	{
 		home += 5;
-		home = ft_strjoin(home, "./history");
+		home = ft_strjoin(home, "/.history");
 		if (!home)
 			error(data, "Memory problems when adding to history");
 		fd = open(home, O_CREAT | O_RDWR | O_APPEND, 0644);

--- a/src/history.c
+++ b/src/history.c
@@ -1,0 +1,81 @@
+#include "minishell.h"
+
+char	*get_home(char **envp)
+{
+	int	i;
+	
+	i = 0;
+	while (envp[i])
+	{
+		if (!ft_strncmp("HOME=", envp[i], 5))
+			return (envp[i]);
+		i++;
+	}
+	return (NULL);
+}
+
+void	load_history(int fd)
+{
+	char *line;
+	char *to_add;
+
+	line = get_next_line(fd);
+	if (line)
+		to_add = ft_substr(line, 0, (ft_strlen(line) - 1));
+	while (line)
+	{
+		add_history(to_add);
+		free(to_add);
+		free(line);
+		line = get_next_line(fd);
+		if (line)
+			to_add = ft_substr(line, 0, (ft_strlen(line) - 1));
+	}
+}
+
+void	get_past_history(char **envp, t_minishell *data)
+{
+	int		fd;
+	char	*home;
+
+	home = get_home(envp);
+	if (home)
+	{
+		home += 5;
+		// printf("%s\n",home);
+		// exit(0);
+		home = ft_strjoin(home, "./history");
+		if (!home)
+			error(data, "Memory problems when loading history");
+		fd = open(home, O_CREAT | O_RDWR | O_APPEND, 0644);
+		free(home);
+		if (fd == -1 )
+			error(data, "Could not load history");
+		load_history(fd);
+		close(fd);
+	}
+}
+void	join_history(char *cmd, t_minishell *data, char **envp)
+{
+	int		fd;
+	char	*home;
+	
+	if (!cmd || !(*cmd))
+		return ;
+	home = get_home(envp);
+	if (home)
+	{
+		home += 5;
+		home = ft_strjoin(home, "./history");
+		if (!home)
+			error(data, "Memory problems when adding to history");
+		fd = open(home, O_CREAT | O_RDWR | O_APPEND, 0644);
+		free(home);
+		if (fd == -1)
+			error(data, "Could not add to history");
+		ft_putstr_fd(cmd, fd);
+		ft_putchar_fd('\n', fd);
+		close(fd);
+	}
+	add_history(cmd);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -64,7 +64,7 @@ void	arguments(t_minishell *data, char **envp) // en el git de referencia, hacen
 			free(line);
 		else 
 		{
-			add_history(line);
+			join_history(line, data, envp);
 			lexer(line, &(data->token_list));
 			token_tmp = data->token_list;
 			parser(&(data->cmd_table), &(data->token_list));
@@ -84,6 +84,7 @@ int	main(int argc, char **argv, char **envp)
 	if (argc != 1 || argv[1])
 		exit(1);
 	data = init(); // iniciar env variables aqui
+	get_past_history(envp, data); 
 	signals(false);
 	arguments(data, envp);
 }


### PR DESCRIPTION
Historial funcionando. 
La idea es crear un archivo invisible dentro de HOME llamado .history donde guardar todos los comandos que se van poniendo (habría que pensar si limpiar este archivo cuando llegue a un número determinado de entries).
La ft readline crea su propio historial, así que antes de entrar al loop de la minishell carga todos los comandos de .history al historial de readline.
Una vez iniciado el loop, cada comando es registrado tanto en .history como en el historial de readline con la ft join_history.

Quedaría mirar como acceder al comando dentro de la minishell. En bash, si usas history te sale el historial de comandos. Queda apuntado como pendiente y dejo este branch con vida